### PR TITLE
Use fallible::TryClone to return error on failed clone instead of Option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ mime_guess = "2.0"
 serde_json = { version = "1.0", optional = true }
 base64 = "0.12"
 percent-encoding = "2.1"
+fallible = "0.1.3"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 encoding_rs = "0.8"

--- a/src/blocking/multipart.rs
+++ b/src/blocking/multipart.rs
@@ -147,7 +147,7 @@ impl Form {
     }
 
     // If predictable, computes the length the request will have
-    // The length should be preditable if only String and file fields have been added,
+    // The length should be predictable if only String and file fields have been added,
     // but not if a generic reader has been added;
     pub(crate) fn compute_length(&mut self) -> Option<u64> {
         self.inner.compute_length()

--- a/src/blocking/request.rs
+++ b/src/blocking/request.rs
@@ -13,26 +13,6 @@ pub type Request = crate::core::request::Request<super::Body>;
 pub type RequestBuilder = crate::core::request::RequestBuilder<super::Body>;
 
 impl Request {
-    /// Attempts to clone the `Request`.
-    ///
-    /// None is returned if a body is which can not be cloned. This can be because the body is a
-    /// stream.
-    pub fn try_clone(&self) -> Option<Request> {
-        let body = if let Some(ref body) = self.body.as_ref() {
-            if let Some(body) = body.try_clone() {
-                Some(body)
-            } else {
-                return None;
-            }
-        } else {
-            None
-        };
-        let mut req = Request::new(self.method().clone(), self.url().clone());
-        *req.headers_mut() = self.headers().clone();
-        req.body = body;
-        Some(req)
-    }
-
     pub(crate) fn into_async(self) -> (async_impl::Request, Option<body::Sender>) {
         use crate::header::CONTENT_LENGTH;
 
@@ -124,56 +104,6 @@ impl RequestBuilder {
         client.execute(self.request?)
     }
 
-    /// Attempts to clone the `RequestBuilder`.
-    ///
-    /// None is returned if a body is which can not be cloned. This can be because the body is a
-    /// stream.
-    ///
-    /// # Examples
-    ///
-    /// With a static body
-    ///
-    /// ```rust
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let builder = reqwest::blocking::RequestBuilder::post("http://httpbin.org/post")
-    ///     .body("from a &str!");
-    /// let clone = builder.try_clone();
-    /// assert!(clone.is_some());
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// Without a body
-    ///
-    /// ```rust
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let builder = reqwest::blocking::RequestBuilder::get("http://httpbin.org/get");
-    /// let clone = builder.try_clone();
-    /// assert!(clone.is_some());
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// With a non-clonable body
-    ///
-    /// ```rust
-    /// # fn run() -> Result<(), Box<dyn std::error::Error>> {
-    /// let builder = reqwest::blocking::RequestBuilder::get("http://httpbin.org/get")
-    ///     .body(reqwest::blocking::Body::new(std::io::empty()));
-    /// let clone = builder.try_clone();
-    /// assert!(clone.is_none());
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn try_clone(&self) -> Option<RequestBuilder> {
-        self.request
-            .as_ref()
-            .ok()
-            .and_then(|req| req.try_clone())
-            .map(|req| RequestBuilder {
-                request: Ok(req),
-            })
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Move Request, RequestBuilder, and Body to proper trait implementation of TryClone to allow TryClone to be pulled into the common Request type